### PR TITLE
Fix index out of bound

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -27,7 +27,7 @@ func New(size uint64) *Bitmap {
 
 // SetBit sets bit at `offset` to value `v`.
 func (b *Bitmap) SetBit(offset uint64, v bool) bool {
-	if offset > b.bitsize {
+	if offset >= b.bitsize {
 		return false
 	}
 	index, bit := offset>>3, offset&7 // offset/8, offset%8
@@ -41,7 +41,7 @@ func (b *Bitmap) SetBit(offset uint64, v bool) bool {
 
 // GetBit returns the value of bit at `offset`.
 func (b *Bitmap) GetBit(offset uint64) bool {
-	if offset > b.bitsize {
+	if offset >= b.bitsize {
 		return false
 	}
 	index, bit := offset>>3, offset&7

--- a/bitmap.go
+++ b/bitmap.go
@@ -52,3 +52,12 @@ func (b *Bitmap) GetBit(offset uint64) bool {
 func (b *Bitmap) Size() uint64 {
 	return b.bitsize
 }
+
+func (b *Bitmap) GetBitSets() uint64 {
+	var total uint64
+	for i:=0; i < len(b.data); i++ {
+		total += uint64(bits.OnesCount(uint(b.data[i])))
+	}
+
+	return total
+}

--- a/bitmap.go
+++ b/bitmap.go
@@ -2,7 +2,7 @@
 package bitmap
 
 // MaxBitmapSize is the maximum bitmap size (in bits).
-const MaxBitmapSize uint64 = 0x01 << 40
+const MaxBitmapSize uint64 = 0x01 << 64-1
 
 // Bitmap represents a bitmap.
 type Bitmap struct {


### PR DESCRIPTION
If you have an input a size with multiplicity by 8 and you try to access with an offset of the same value of size, you'll end up with an index out of bound exception.

Example:
size = 8
offset = 8
```go
bitmap.New(uint64(8))
bitmap.Set(uint64(8), true)
```